### PR TITLE
SwiftData: session model migration (in progress)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ studyAppUITests/
 build/
 xcuserdata/
 *.xcbkptlist
-.claude/
+studyApp.xcodeproj/project.pbxproj

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,353 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+---
+
+## Quick Start
+
+**Build and run:**
+```bash
+xcodebuild build -project studyApp.xcodeproj -scheme studyApp -destination generic/platform=iOS
+open studyApp.xcodeproj  # then run from Xcode
+```
+
+**Run tests:**
+```bash
+xcodebuild test -project studyApp.xcodeproj -scheme studyApp
+```
+
+---
+
+## Architecture Overview
+
+StudyApp is a **SwiftUI-based iOS app** that combines social study tracking, focus timer tools, and group collaboration. It follows **MVVM** pattern with **SwiftData** for persistence (migration in progress).
+
+### What is MVVM?
+MVVM separates UI concerns from business logic. **Model** = your data (subjects, sessions), **View** = what the user sees (SwiftUI), **ViewModel** = the glue that transforms model data into UI-ready state. This keeps Views simple and testable.
+
+**Main layers:**
+- **App**: Entry point (`StudyAppApp.swift`) and tab navigation (`MainTabView.swift`)
+- **Views**: UI organized by feature (Social, Focus, Groups, Settings, Profile) — displays data and responds to user taps
+- **ViewModels**: State management and business logic — holds form state, handles CRUD operations, transforms data for display
+- **Models**: Data models with SwiftData (`@Model final class`) — definitions of your data, persisted to disk
+- **Resources**: Assets and sample data
+
+See [AppOverview.md](docs/AppOverview.md) for the full folder structure and [SwiftData.md](studyApp/App/docs/SwiftData.md) for data layer patterns.
+
+---
+
+## Key Architectural Decisions
+
+### 1. SwiftData Migration (In Progress)
+
+**Current state:** Models are being migrated from manual JSON persistence to SwiftData.
+
+- `Subject.swift` ✅ Already a `@Model final class`
+- `StudyAppApp.swift` ✅ Already has `.modelContainer(for: [...])`
+- Views still need migration to use `@Query` and `modelContext`
+
+**What is SwiftData?**
+SwiftData is Apple's modern persistence layer (like a lightweight database). Instead of writing data to JSON files manually, SwiftData handles saving/loading for you. It uses a **container** (the actual database file on disk) and a **context** (your handle to read/write data in the current session).
+
+**How it works:**
+- `modelContainer` in app root = creates/manages the database file (created once in `StudyAppApp`, shared across the entire app)
+- `@Query var items: [Item]` in views = a live, auto-updating list that re-renders whenever the underlying data changes (powered by SwiftData)
+- `@Environment(\.modelContext)` in views = your write handle — use this to insert, update, or delete data in the current session
+- When you modify data via `modelContext` and call `save()`, it persists to disk
+
+See [SwiftData.md](studyApp/App/docs/SwiftData.md) for detailed patterns.
+
+### 2. MVVM + SwiftData Pattern
+
+**Why split into ViewModel and View?**
+- **ViewModel** = the business logic (managing form state, saving to database)
+- **View** = just displaying data and calling ViewModel methods when user taps buttons
+
+This keeps Views simple and reusable. A View doesn't need to know *how* data is saved; it just calls a ViewModel method.
+
+**ViewModel responsibilities:**
+- Hold transient UI state (simple `var` properties for forms, like `newSubjectName` while the user is typing — `@Observable` tracks changes automatically)
+- Provide methods for CRUD operations (Create, Read, Update, Delete) that accept `ModelContext` as a parameter
+- Use `@Observable` macro (modern replacement for `@ObservableObject` — SwiftUI watches changes and re-renders)
+- NO `@State` in classes (only in `struct View`) — `@Observable` handles change tracking
+
+**View responsibilities:**
+- Display data via `@Query` (this *must* be in views, not ViewModels — SwiftUI needs direct access to re-render)
+- Initialize the ViewModel non-optionally (the `modelContext` is always available via `@Environment` at view declaration time)
+- Pass `modelContext` to ViewModel methods when calling them — dependency injection at call site
+- Handle navigation and UI layout — the "what should I show" logic
+
+**Example split:**
+```swift
+// SubjectsEditorVM.swift — the business logic
+@Observable
+class SubjectsEditorVM {
+    // Form state: @Observable watches these automatically (no @State needed in classes)
+    var newSubjectName: String = ""
+    var newSubjectCode: String = ""
+    
+    var canAddSubject: Bool {
+        newSubjectName.count > 0 && newSubjectCode.count > 0
+    }
+    
+    // Context passed at call time, not stored. Keeps VM simple to initialize
+    // and easier to test (can pass different contexts if needed)
+    func addSubject(context: ModelContext) {
+        guard canAddSubject else { return }
+        context.insert(Subject(name: newSubjectName, code: newSubjectCode.uppercased()))
+        newSubjectName = ""
+        newSubjectCode = ""
+    }
+    
+    func removeSubject(_ subject: Subject, context: ModelContext) {
+        context.delete(subject)
+    }
+}
+
+// SubjectsEditor.swift — the view/UI layer
+struct SubjectsEditor: View {
+    // Get all subjects from the database — automatically updates when data changes
+    @Query var subjects: [Subject]
+    
+    // Get write access to the database (always available from app root's .modelContainer)
+    @Environment(\.modelContext) var modelContext
+    
+    // ViewModel is non-optional because modelContext is guaranteed at view initialization.
+    // The app root sets up .modelContainer(), which provides modelContext to all child views.
+    // No need for .onAppear initialization or optional unwrapping.
+    @State private var vm = SubjectsEditorVM()
+    
+    var body: some View {
+        VStack {
+            List {
+                ForEach(subjects) { subject in
+                    Text(subject.name)
+                }
+                .onDelete { indexSet in
+                    indexSet.forEach { index in
+                        vm.removeSubject(subjects[index], context: modelContext)
+                    }
+                }
+            }
+            
+            TextField("Subject name", text: $vm.newSubjectName)
+            
+            Button("Add") {
+                vm.addSubject(context: modelContext)
+            }
+            .disabled(!vm.canAddSubject)
+        }
+    }
+}
+```
+
+### 3. Layer Rules
+
+**Models layer:**
+- Only data definitions (`@Model final class` with `@Attribute` and `@Relationship` decorators)
+- No business logic, no UI imports — models don't "do" anything, they just *are* data
+- Use SwiftData attributes: `@Attribute(.unique)` to enforce database constraints, `@Relationship` to link models together
+- Example: `Subject` is just a data container with a name and code; it doesn't fetch or save itself
+
+**ViewModels:**
+- `@Observable` classes (modern replacement for `@ObservableObject`), not the old `@ObservableObject` macro
+- Hold form state (like temporary user input) as simple `var` properties — NO `@State` (that's only for Views)
+- Provide CRUD methods that accept `ModelContext` as a parameter, not stored in init — this keeps VMs simple and non-optional in Views
+- No SwiftUI imports (no `import SwiftUI`) — just foundation imports; the ViewModel doesn't know it's powering UI
+
+**Views:**
+- SwiftUI-only state management: `@State` for transient UI state, `@Query` for database queries
+- Initialize ViewModels non-optionally: `@State private var vm = SubjectsEditorVM()` — `modelContext` is guaranteed via `@Environment` from the app root
+- Pass `modelContext` to ViewModel methods at call time: `vm.addSubject(context: modelContext)` — keeps the ViewModel simple and testable
+- Use previews with `.modelContainer(for: Model.self, inMemory: true)` to test without touching the real database
+- Views are "dumb" about persistence — they just display data and call ViewModel methods
+
+**Stores (legacy, phasing out):**
+- `UserProfileStore`, `SubjectStore` use old JSON persistence (reading/writing JSON files manually)
+- Being replaced by SwiftData models in Views + ViewModels
+- Avoid adding new dependencies on these — if you're touching a Store, consider migrating to SwiftData instead
+
+---
+
+## Common Tasks
+
+### Adding a New Model
+
+1. Create in `Models/` as `@Model final class`
+2. Add to `.modelContainer(for: [...])` in `StudyAppApp.swift` — this tells SwiftData to create a table for this model
+3. Use `@Attribute(.unique)` on ID fields to prevent duplicates, provide default values for all properties
+
+**Why?** Models are the source of truth. SwiftData needs to know about every model you want to persist, so the container must include it.
+
+### Migrating a View to SwiftData
+
+1. Create a ViewModel (`ViewModels/Feature/FeatureVM.swift`) to hold form state and CRUD logic as an `@Observable` class
+2. Move form state (like `newName: String = ""`) and methods (like `addItem(context:)`) into the VM — methods accept `ModelContext` as a parameter
+3. In the View: add `@Query var items` to fetch data, `@Environment(\.modelContext)` to get database write access
+4. Initialize the ViewModel non-optionally: `@State private var vm = FeatureVM()` — pass `modelContext` to methods when calling them
+5. Remove dependencies on old `Store` singletons
+6. Test with previews to ensure data flows correctly (add `.modelContainer(for: Model.self, inMemory: true)`)
+
+**Why?** Old Stores used JSON files and singletons. SwiftData is faster and simpler. Views become lighter and easier to test. Non-optional VMs eliminate unwrapping clutter.
+
+### Writing Previews with SwiftData
+
+```swift
+#Preview {
+    SubjectsEditor()
+        // Create an in-memory database for preview (not saved to disk)
+        // This lets you test UI without touching the real database
+        .modelContainer(for: Subject.self, inMemory: true)
+}
+```
+
+**Why?** Previews need a valid `.modelContainer`, or SwiftUI can't render. `inMemory: true` keeps preview databases isolated from real data.
+
+### Filtering with @Query
+
+```swift
+@Query(
+    // Filter: only subjects whose name contains "Math"
+    filter: #Predicate<Subject> { $0.name.contains("Math") },
+    // Sort: by createdAt date, ascending
+    sort: \Subject.createdAt
+)
+var mathSubjects: [Subject]
+```
+
+**Why?** `@Query` fetches *all* data by default, which is slow. Filtering and sorting at the database level is more efficient than fetching everything and filtering in Swift.
+
+---
+
+## Current Maintenance Notes
+
+See [TODO.txt](TODO.txt) for deferred UI decisions and [plan.md](plan.md) for legacy architecture decisions (some now outdated by SwiftData migration).
+
+**Active work:**
+- Migrating Views to use `@Query` and `modelContext` directly
+- Phasing out `UserProfileStore` and `SubjectStore` JSON persistence
+
+
+---
+
+## Code Style
+
+- **Minimal comments for simple code** (clean names explain *what*); add comments only when the *why* is non-obvious
+  - ❌ `// Loop through subjects` — obvious
+  - ✅ `// Filter active subjects only; inactive ones cause perf issues in the list` — explains a constraint
+- No docstrings for methods — if the method name is unclear, rename the method
+- Use property names that are self-explanatory: `newSubjectName` is clearer than `tempName` or `n`
+- Prefer `final class` for all models — prevents accidental subclassing and keeps inheritance boundaries clear
+- Group related state together in ViewModels — `newSubjectName` and `newSubjectCode` belong near each other
+- **When adding complex logic, comment it:** SwiftData queries, database migrations, or non-obvious Swift patterns should have a comment explaining the intent
+
+---
+
+## Debugging SwiftData
+
+**Check saved data:**
+```swift
+@Query var allSubjects: [Subject]
+// Temporarily add this to a view to see how many subjects exist
+Text("Subjects: \(allSubjects.count)")
+```
+
+**Why?** If data isn't persisting, check the count. If it's always 0, data isn't being saved. If the count is stale, the View isn't observing `@Query` correctly.
+
+**Force save:**
+```swift
+// After modifying modelContext (insert/delete), explicitly save to disk
+try? modelContext.save()
+```
+
+**Why?** SwiftData doesn't auto-save; you must call `save()`. Without it, changes exist in memory but disappear when the app closes.
+
+**Delete all data (testing):**
+```swift
+// Wipe all subjects from the database — useful for testing
+try? modelContext.delete(model: Subject.self)
+try? modelContext.save()
+```
+
+**Why?** During development, you may want a clean slate. This removes all data for a model type. Call `save()` after to persist the deletion to disk.
+
+**Common issues:**
+- Data appears in one session but vanishes when you restart → you forgot to call `save()`
+- Changes don't appear in the UI → `@Query` wasn't used, or the ViewModel didn't trigger a re-render
+- Two parts of the app see different data → multiple `modelContext`s exist; ensure only one is used per app lifecycle
+
+---
+
+## External Docs
+
+- [App overview](docs/AppOverview.md) — feature description and folder structure
+- [SwiftData guide](studyApp/App/docs/SwiftData.md) — models, relationships, queries, patterns
+- [Settings documentation](studyApp/App/docs/AppSettings.md) — user preferences and theme
+
+---
+
+## Git Workflow
+
+- Main branch: `master`
+- Feature branches: descriptive names (`timer-fix`, `swiftdata-migration`, etc.)
+- Commits: short, focused changes with clear messages
+- No force pushes to `master`
+
+# General Behavioural Guidelines
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/docs/AppSettings.md
+++ b/docs/AppSettings.md
@@ -1,0 +1,34 @@
+//
+//  AppSettings.md
+//  studyApp
+//
+//  Created by brad wils on 14/3/26.
+//
+
+# Process
+
+- //
+//  AppSettings.md
+//  studyApp
+//
+//  Created by brad wils on 14/3/26.
+//
+
+# Process
+
+- App settings - injected into .environment as an .environmentObject.
+
+## Themes
+- There is a list of themes within the app settings
+
+- Each theme is manual at the moment with 3 colours (for debugging)
+    - default themes; always present in the themePicker, not saved anywhere, hard-coded
+    - custom themes can be made (later), and will be saved seperately, and custom-encoded to make sure it's encodable.
+
+
+
+Functions
+
+getUserThemesFromStorage() -> //TODO
+- retrieves stored user themes, which are held in the format
+

--- a/docs/AppSettings.md
+++ b/docs/AppSettings.md
@@ -5,30 +5,6 @@
 //  Created by brad wils on 14/3/26.
 //
 
-# Process
+# App Settings
 
-- //
-//  AppSettings.md
-//  studyApp
-//
-//  Created by brad wils on 14/3/26.
-//
-
-# Process
-
-- App settings - injected into .environment as an .environmentObject.
-
-## Themes
-- There is a list of themes within the app settings
-
-- Each theme is manual at the moment with 3 colours (for debugging)
-    - default themes; always present in the themePicker, not saved anywhere, hard-coded
-    - custom themes can be made (later), and will be saved seperately, and custom-encoded to make sure it's encodable.
-
-
-
-Functions
-
-getUserThemesFromStorage() -> //TODO
-- retrieves stored user themes, which are held in the format
-
+- App settings are injected into the environment as an `.environmentObject`.

--- a/docs/HowToTestSwiftData.md
+++ b/docs/HowToTestSwiftData.md
@@ -1,0 +1,422 @@
+# Testing SwiftData: Patterns & Examples
+
+This guide shows how to write tests for SwiftData models and ViewModels using in-memory containers for isolation and speed.
+
+---
+
+## Foundation: Test Helper
+
+Create `TestHelpers.swift` in your test bundle. This is reusable across all tests.
+
+```swift
+import Foundation
+import SwiftData
+import XCTest
+
+/// Creates an in-memory SwiftData container for testing.
+/// Use this in setUp() for every test to ensure isolation and speed.
+func createTestModelContainer() -> ModelContainer {
+    // isStoredInMemoryOnly: true means data is NOT saved to disk.
+    // Each test gets a fresh, empty database. Tests don't interfere.
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    
+    // Include ALL models your app uses (or just the ones being tested).
+    // SwiftData needs to know about every @Model you'll persist.
+    return try! ModelContainer(
+        for: Subject.self, StudySession.self, StudyGroup.self,
+        configurations: [config]
+    )
+}
+
+/// Creates a ModelContext from a test container.
+/// Use this to insert/query data in your tests.
+func createTestContext(container: ModelContainer? = nil) -> ModelContext {
+    let container = container ?? createTestModelContainer()
+    return ModelContext(container)
+}
+```
+
+**Why?**
+- `isStoredInMemoryOnly: true` keeps tests fast (no disk I/O) and isolated (no real data touched)
+- Fresh container per test = no test pollution (test A's data doesn't affect test B)
+- Centralizing this helper means you change it once if SwiftData patterns shift
+
+---
+
+## Example 1: Testing a ViewModel's CRUD Logic
+
+Let's test `SubjectsEditorVM` (add, remove, validation).
+
+```swift
+import XCTest
+@testable import studyApp
+
+class SubjectsEditorVMTests: XCTestCase {
+    // Set up fresh ViewModel and context for each test
+    var vm: SubjectsEditorVM!
+    var context: ModelContext!
+    
+    override func setUp() {
+        super.setUp()
+        // Fresh context = fresh database for this test
+        context = createTestContext()
+        // Initialize ViewModel (it holds UI state, not persistence logic)
+        vm = SubjectsEditorVM()
+    }
+    
+    // MARK: - Validation Tests (no database needed)
+    
+    /// Test that canAddSubject is false when form is empty.
+    /// Validation logic doesn't touch the database—test it in isolation.
+    func testCanAddSubjectWhenEmpty() {
+        XCTAssertFalse(vm.canAddSubject, "canAddSubject should be false initially")
+    }
+    
+    /// Test that form state updates as user types.
+    /// This tests the ViewModel's UI state tracking.
+    func testCanAddSubjectWhenNameProvided() {
+        vm.newSubjectName = "Mathematics"
+        // Code is still empty, so canAddSubject should still be false
+        XCTAssertFalse(vm.canAddSubject, "canAddSubject is false without code")
+        
+        vm.newSubjectCode = "MATH101"
+        // Now both fields are filled
+        XCTAssertTrue(vm.canAddSubject, "canAddSubject is true when both fields filled")
+    }
+    
+    // MARK: - Persistence Tests (uses ModelContext)
+    
+    /// Test that addSubject saves to the database.
+    /// ViewModel method accepts context as a parameter (dependency injection).
+    /// We verify by querying the database afterward.
+    func testAddSubjectSavesToDatabase() {
+        // Set up the form
+        vm.newSubjectName = "Physics"
+        vm.newSubjectCode = "PHYS101"
+        
+        // Call the ViewModel method, passing the test context
+        vm.addSubject(context: context)
+        
+        // Verify it was actually saved: fetch all subjects
+        let descriptor = FetchDescriptor<Subject>()
+        let allSubjects = try! context.fetch(descriptor)
+        XCTAssertEqual(allSubjects.count, 1, "Should have inserted one subject")
+        XCTAssertEqual(allSubjects[0].name, "Physics", "Saved subject should have correct name")
+        XCTAssertEqual(allSubjects[0].code, "PHYS101", "Saved subject should have correct code")
+    }
+    
+    /// Test that the form clears after successful add.
+    /// This is ViewModel behavior: after saving, reset the UI fields.
+    func testAddSubjectClearsForm() {
+        vm.newSubjectName = "Chemistry"
+        vm.newSubjectCode = "CHEM101"
+        
+        vm.addSubject(context: context)
+        
+        // Form should be reset so user can add another subject
+        XCTAssertEqual(vm.newSubjectName, "", "newSubjectName should be cleared")
+        XCTAssertEqual(vm.newSubjectCode, "", "newSubjectCode should be cleared")
+    }
+    
+    /// Test that removing a subject deletes it from the database.
+    /// Verify using a fetch afterward.
+    func testRemoveSubjectDeletesFromDatabase() {
+        // First, add a subject to remove
+        let newSubject = Subject(name: "Biology", code: "BIO101")
+        context.insert(newSubject)
+        try! context.save()
+        
+        // Verify it exists
+        var descriptor = FetchDescriptor<Subject>()
+        var subjects = try! context.fetch(descriptor)
+        XCTAssertEqual(subjects.count, 1)
+        
+        // Remove via ViewModel
+        vm.removeSubject(newSubject, context: context)
+        
+        // Verify it's gone
+        subjects = try! context.fetch(descriptor)
+        XCTAssertEqual(subjects.count, 0, "Subject should be deleted")
+    }
+}
+```
+
+**Key Patterns:**
+- **Fresh context per test:** `setUp()` creates a clean database
+- **Dependency injection:** Pass `context` to ViewModel methods; ViewModel doesn't store it
+- **Fetch to verify:** After calling ViewModel methods, query the database to confirm persistence
+- **Validation without DB:** Test computed properties (`canAddSubject`) without touching the database—they're just Swift logic
+
+---
+
+## Example 2: Testing with Predicates & Filtering
+
+SwiftData queries use predicates for filtering. Test that your queries return the right data.
+
+```swift
+class StudySessionVMTests: XCTestCase {
+    var vm: StudySessionVM!
+    var context: ModelContext!
+    
+    override func setUp() {
+        super.setUp()
+        context = createTestContext()
+        vm = StudySessionVM()
+    }
+    
+    /// Test that fetching today's sessions filters correctly.
+    /// Predicates are how you ask "give me only sessions from today".
+    func testFetchTodaysSessions() {
+        let today = Date()
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+        
+        // Insert sessions across different dates
+        let todaySession = StudySession(subject: "Math", startTime: today, duration: 30)
+        let tomorrowSession = StudySession(subject: "Physics", startTime: tomorrow, duration: 45)
+        let yesterdaySession = StudySession(subject: "Chemistry", startTime: yesterday, duration: 20)
+        
+        context.insert(todaySession)
+        context.insert(tomorrowSession)
+        context.insert(yesterdaySession)
+        try! context.save()
+        
+        // Fetch only today's sessions using a predicate.
+        // The #Predicate macro is SwiftData's type-safe way to filter.
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: today)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
+        
+        let descriptor = FetchDescriptor<StudySession>(
+            predicate: #Predicate { session in
+                session.startTime >= startOfDay && session.startTime < endOfDay
+            }
+        )
+        let todaysSessions = try! context.fetch(descriptor)
+        
+        XCTAssertEqual(todaysSessions.count, 1, "Should fetch only today's session")
+        XCTAssertEqual(todaysSessions[0].subject, "Math")
+    }
+    
+    /// Test sorting: verify sessions are returned in the order you expect.
+    /// The sort parameter in FetchDescriptor controls order.
+    func testSessionsSortedByDurationDescending() {
+        let session1 = StudySession(subject: "Math", startTime: Date(), duration: 30)
+        let session2 = StudySession(subject: "Physics", startTime: Date(), duration: 60)
+        let session3 = StudySession(subject: "Chemistry", startTime: Date(), duration: 15)
+        
+        context.insert(session1)
+        context.insert(session2)
+        context.insert(session3)
+        try! context.save()
+        
+        // FetchDescriptor with sort: descending by duration
+        let descriptor = FetchDescriptor<StudySession>(
+            sortBy: [SortDescriptor(\StudySession.duration, order: .reverse)]
+        )
+        let sorted = try! context.fetch(descriptor)
+        
+        // Verify order: longest first
+        XCTAssertEqual(sorted[0].duration, 60)
+        XCTAssertEqual(sorted[1].duration, 30)
+        XCTAssertEqual(sorted[2].duration, 15)
+    }
+    
+    /// Test combining predicate and sort.
+    /// You often need both: filter AND order the results.
+    func testFetchActiveSessionsSortedByRecency() {
+        let now = Date()
+        
+        let activeRecent = StudySession(subject: "Math", startTime: now, duration: 45, isActive: true)
+        let activeOld = StudySession(subject: "Physics", startTime: Calendar.current.date(byAdding: .day, value: -1, to: now)!, duration: 30, isActive: true)
+        let inactiveRecent = StudySession(subject: "Chemistry", startTime: now, duration: 60, isActive: false)
+        
+        context.insert(activeRecent)
+        context.insert(activeOld)
+        context.insert(inactiveRecent)
+        try! context.save()
+        
+        // Fetch active sessions, sorted newest first
+        let descriptor = FetchDescriptor<StudySession>(
+            predicate: #Predicate { $0.isActive },
+            sortBy: [SortDescriptor(\StudySession.startTime, order: .reverse)]
+        )
+        let results = try! context.fetch(descriptor)
+        
+        XCTAssertEqual(results.count, 2, "Should fetch 2 active sessions")
+        XCTAssertEqual(results[0].subject, "Math", "Newest active should be first")
+        XCTAssertEqual(results[1].subject, "Physics")
+    }
+}
+```
+
+**Key Patterns:**
+- **#Predicate macro:** Type-safe way to filter data. Compiler checks your logic.
+- **SortDescriptor:** Controls the order of results (ascending/descending)
+- **Combined:** Use both predicate and sort together for complex queries
+- **Verify with assertions:** Check count and order to confirm the query works as expected
+
+---
+
+## Example 3: Testing Relationships
+
+If your models have relationships (e.g., Subject has many StudySessions), test that associations work.
+
+```swift
+class StudySessionRelationshipTests: XCTestCase {
+    var context: ModelContext!
+    
+    override func setUp() {
+        super.setUp()
+        context = createTestContext()
+    }
+    
+    /// Test that creating a session linked to a subject works.
+    /// Relationships are how models reference each other in SwiftData.
+    func testSessionLinkedToSubject() {
+        let subject = Subject(name: "Mathematics", code: "MATH101")
+        let session = StudySession(subject: subject, duration: 45)
+        
+        context.insert(subject)
+        context.insert(session)
+        try! context.save()
+        
+        // Fetch the session and verify the relationship is intact
+        let descriptor = FetchDescriptor<StudySession>()
+        let sessions = try! context.fetch(descriptor)
+        
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions[0].subject.name, "Mathematics", "Session should reference correct subject")
+    }
+    
+    /// Test cascade delete: if a subject is deleted, related sessions are also deleted.
+    /// This depends on your @Relationship configuration (e.g., deleteRule: .cascade).
+    func testDeleteSubjectCascadesToSessions() {
+        let subject = Subject(name: "Physics", code: "PHYS101")
+        let session = StudySession(subject: subject, duration: 60)
+        
+        context.insert(subject)
+        context.insert(session)
+        try! context.save()
+        
+        // Verify both exist
+        var subjectDescriptor = FetchDescriptor<Subject>()
+        var sessionDescriptor = FetchDescriptor<StudySession>()
+        XCTAssertEqual(try! context.fetch(subjectDescriptor).count, 1)
+        XCTAssertEqual(try! context.fetch(sessionDescriptor).count, 1)
+        
+        // Delete the subject
+        context.delete(subject)
+        try! context.save()
+        
+        // If cascade is configured, the session should also be gone
+        XCTAssertEqual(try! context.fetch(subjectDescriptor).count, 0)
+        XCTAssertEqual(try! context.fetch(sessionDescriptor).count, 0, "Session should be cascade-deleted with subject")
+    }
+}
+```
+
+**Key Patterns:**
+- **Insert related models:** Insert both the parent and related model
+- **Verify relationships:** After inserting, fetch and check that the reference is correct
+- **Test delete rules:** Verify cascade/orphan delete behavior works as expected
+
+---
+
+## Best Practices
+
+| Do | Don't |
+|----|-------|
+| Use `isStoredInMemoryOnly: true` in tests | Use the real, disk-based container in tests |
+| Fresh context per test (in `setUp()`) | Reuse the same context across multiple tests |
+| Pass `context` to ViewModel methods | Store `context` in the ViewModel itself |
+| Test ViewModel logic, then verify via fetch | Trust that the ViewModel saved correctly without checking |
+| Use `#Predicate` for filtering | Fetch all data and filter in Swift (slow and error-prone) |
+| Test validation separately from persistence | Combine validation and database tests in one test |
+| Create seed data in the test (or setUp) | Rely on data existing from a previous test run |
+
+---
+
+## Common Patterns
+
+### Pattern 1: Verify Insert
+```swift
+// Set up, call ViewModel method, then fetch to verify
+let initialCount = try! context.fetch(FetchDescriptor<Subject>()).count
+vm.addSubject(context: context)
+let finalCount = try! context.fetch(FetchDescriptor<Subject>()).count
+XCTAssertEqual(finalCount, initialCount + 1)
+```
+
+### Pattern 2: Verify Update
+```swift
+let subject = Subject(name: "Math", code: "MATH101")
+context.insert(subject)
+try! context.save()
+
+subject.name = "Advanced Math"  // Modify
+try! context.save()  // Persist the change
+
+// Fetch and verify
+let fetched = try! context.fetch(FetchDescriptor<Subject>()).first
+XCTAssertEqual(fetched?.name, "Advanced Math")
+```
+
+### Pattern 3: Verify Delete
+```swift
+let subject = Subject(name: "Physics", code: "PHYS101")
+context.insert(subject)
+try! context.save()
+
+context.delete(subject)
+try! context.save()
+
+let count = try! context.fetch(FetchDescriptor<Subject>()).count
+XCTAssertEqual(count, 0)
+```
+
+### Pattern 4: Verify Predicate
+```swift
+// Insert data
+let math = Subject(name: "Math", code: "MATH101")
+let physics = Subject(name: "Physics", code: "PHYS101")
+context.insert(math)
+context.insert(physics)
+try! context.save()
+
+// Fetch with predicate
+let descriptor = FetchDescriptor<Subject>(
+    predicate: #Predicate { $0.name.contains("Math") }
+)
+let results = try! context.fetch(descriptor)
+XCTAssertEqual(results.count, 1)
+```
+
+---
+
+## Debugging Test Failures
+
+**Test fails: "Could not find any element matching the predicate"**
+- Your predicate is too strict. Print what's in the database:
+  ```swift
+  let allItems = try! context.fetch(FetchDescriptor<Item>())
+  print("All items: \(allItems.map { $0.name })")
+  ```
+
+**Test passes, but data doesn't persist in the real app**
+- You forgot to call `try! context.save()` in your ViewModel after insert/delete/update.
+
+**Tests pass individually but fail when run together**
+- Each test should have a fresh context. Check your `setUp()` method creates a new container.
+
+**"ModelContext not configured" error**
+- You forgot `.modelContainer(for: Model.self, inMemory: true)` in your preview or test.
+
+---
+
+## Next Steps
+
+1. Copy `TestHelpers.swift` to your test bundle
+2. Write a test for your most critical ViewModel (e.g., `StudySessionVM`)
+3. Start with validation tests (no database), then add persistence tests
+4. Expand predicates and relationships as you add more complex queries

--- a/docs/Models/StudySession.md
+++ b/docs/Models/StudySession.md
@@ -1,0 +1,57 @@
+# StudySession
+
+## Overview
+StudySession is a SwiftData Model that captures a single study session from the user, which holds all of the information that the user wants about the session, including some analytics. 
+
+
+
+## Properties
+- SwiftData Model
+
+### Used Structs
+- SessionLocation
+- StudyBreak
+
+
+
+
+
+## Initializing
+### Primary
+- Nil can be passed for most values except for:
+    - subject: Subject
+    - startedAt: Date
+```swift
+    StudySession(
+        id: UUID = UUID(),
+        subject: Subject,
+        subjectName: String?,
+        startedAt: Date,
+        endedAt: Date?,
+        lastPausedAt: Date?,
+        activeDuration: TimeInterval = 0,
+        totalBreakDuration: TimeInterval = 0,
+        breaks: [StudyBreak]?,
+        friends: [String] = [], //TODO later
+        location: SessionLocation?,
+        studyScore: Int?,
+        notes: String?,
+        interruptionCount: Int?
+        )
+```
+
+```swift
+Initialise without any values
+```
+
+
+### Background
+### Convinience
+
+## SwiftData Relationship
+
+
+
+## Used Flows
+
+

--- a/docs/Models/StudySession/SessionLocation.md
+++ b/docs/Models/StudySession/SessionLocation.md
@@ -1,0 +1,35 @@
+# SessionLocation
+
+## Overview
+SessionLocation is a SwiftData Model that captures location metadata for a study session. It stores geographic coordinates and descriptive labels for where a user studied. Currently a placeholder for future location tagging features.
+
+## Properties
+| Name | Type | Description |
+|------|------|-------------|
+| `locationDescription` | `String?` | User-friendly description of the location |
+| `latitude` | `Double?` | Geographic latitude coordinate |
+| `longitude` | `Double?` | Geographic longitude coordinate |
+| `locationLabel` | `String?` | Short tag/label for the location |
+
+## Initializers
+
+### Designated Initializer
+```swift
+init(locationDescription: String? = nil, latitude: Double? = nil, longitude: Double? = nil, locationLabel: String? = nil)
+```
+Full control over all fields. All parameters are optional with nil defaults.
+
+### Convenience Initializers
+```swift
+convenience init(latitude: Double, longitude: Double)
+```
+Quick initialization with just coordinates. Location description and label default to nil.
+
+```swift
+convenience init()
+```
+Placeholder initializer for testing or default cases. Creates a dummy location with placeholder values.
+
+## SwiftData Relationship
+- **Embedded in**: `StudySession.location` (optional relationship)
+- **Used for**: Tagging where a study session occurred

--- a/docs/Models/StudySession/StudySession.md
+++ b/docs/Models/StudySession/StudySession.md
@@ -1,0 +1,37 @@
+# StudySession
+
+## Overview
+StudySession is a SwiftData Model that captures a single study session from the user, which holds all of the information that the user wants about the session, including some analytics. 
+
+
+
+## Properties
+### Used Structs
+**SessionLocation**
+    Saves & Tags locations that were studied at, saved by the user.
+    - LocationDescription: Double <optional>
+    - Latitude: Double <optional>
+    - Longitude: Double <optional>
+    - LocationLabel: String
+     
+
+
+
+
+
+
+
+
+
+## Initializers
+### Primary
+### Background
+### Convinience
+
+## SwiftData Relationship
+
+
+
+## Used Flows
+
+

--- a/docs/SwiftDataImplementation.md
+++ b/docs/SwiftDataImplementation.md
@@ -1,0 +1,478 @@
+# 20/5 SwiftData Implementation Guide
+
+This is the **project-specific migration playbook** for StudyApp — what to change, in which file, and why, in the order that makes sense. It assumes you've read [SwiftData.md](SwiftData.md) for the theory. This doc won't re-teach that — instead, it'll reaffirm just enough to make each step click while you're actively implementing.
+
+---
+
+## Current State at a Glance
+
+| File | Status | Notes |
+|---|---|---|
+| `Models/Subject.swift` | ✅ Done | Proper `@Model final class` |
+| `Models/Backend/Themes.swift` | ✅ Done | Proper `@Model final class` |
+| `ViewModels/Settings/SubjectsEditorVM.swift` | ✅ Done | `@Observable`, context passed at call site |
+| `Models/StudySession.swift` | ⚠️ | `@Model final class` — but `SessionLocation` not flattened, `breaks` missing `@Relationship`, `StudyBreak` still in same file using `TimeInterval` instead of `Date` |
+| `ViewModels/StudyTrackingViewModel.swift` | ⚠️ | Compile errors fixed; all session methods are stubs — persistence not wired up yet |
+| `ViewModels/PureFocusViewModel.swift` | ⚠️ | `@Published` removed ✅; still has `import SwiftUI` (should be removed per layer rules) |
+| `ViewModels/Settings/ThemeSettingsViewModel.swift` | ❌ | Still `ObservableObject` + `@Published` + manual fetch |
+| `ViewModels/SocialFeedViewModel.swift` | ❌ | Still `ObservableObject` + `@Published` |
+| `App/StudyAppApp.swift` | ❌ | `modelContainer` missing `StudySession` and `StudyBreak` |
+
+**The most important remaining work is Steps 2–5** — cleaning up the model files and wiring persistence into the VM. Steps 6–8 are smaller cleanups.
+
+---
+
+## Migration Checklist
+
+- [x] **Step 1** — Fix `StudyTrackingViewModel` compile errors
+- [ ] **Step 2** — Fix `StudyBreak` (separate file, use `Date` instead of `TimeInterval`, add inverse relationship)
+- [ ] **Step 3** — Fix `StudySession` (flatten `SessionLocation`, add `@Relationship` to `breaks`, clean up init)
+- [ ] **Step 4** — Register new models in the app container
+- [ ] **Step 5** — Wire `StudyTrackingViewModel` to save/load via `ModelContext`
+- [ ] **Step 6** — Fix `PureFocusViewModel` (remove `import SwiftUI`)
+- [ ] **Step 7** — Migrate `ThemeSettingsViewModel` to `@Observable` + move fetch to View
+- [ ] **Step 8** — Migrate `SocialFeedViewModel` to `@Observable`
+
+---
+
+## Step 1 — Fix `StudyTrackingViewModel` Compile Errors
+
+**File:** `ViewModels/StudyTrackingViewModel.swift`
+
+Before anything else, this file needs to compile. There are three errors:
+
+**Error 1: `studyScore` is declared twice.**
+
+```swift
+// Remove this duplicate
+var studyScore: Int? = nil // placeholder for user-rated session quality/score
+// (keep the one on line ~42)
+var studyScore: Int? = 0
+```
+
+Keep only one declaration. Use `var studyScore: Int? = nil` — `nil` is the right default (no score until session ends).
+
+**Error 2: `interruptionCount: Int = nil` — `nil` can't be assigned to a non-optional `Int`.**
+
+```swift
+// Before
+var interruptionCount: Int = nil
+
+// After
+var interruptionCount: Int = 0
+```
+
+**Error 3: `resumeSession()` is unclosed — it's missing a closing `}`.** The `endSession` function begins inside `resumeSession`'s body. Add the closing brace after `resumeSession`'s body ends.
+
+Also remove unused imports — `CoreLocation` and `Combine` aren't needed until you actually use them.
+
+**Verify:** `xcodebuild build -project studyApp.xcodeproj -scheme studyApp -destination generic/platform=iOS` succeeds.
+
+---
+
+## Step 2 — Fix `StudyBreak` and Move to Its Own File
+
+**Current file:** `Models/StudySession.swift`
+
+`StudyBreak` is already `@Model final class` — good. But two things need fixing:
+
+1. **`startedAt`/`endedAt` use `TimeInterval` — they should be `Date`.** `TimeInterval` is a raw `Double` (seconds since some reference point). Storing `Date` directly is the SwiftData-idiomatic choice: it's self-documenting, and computed properties like `duration` stay clean.
+
+2. **It lives in `StudySession.swift` — move it to `Models/StudyBreak.swift`.** One type per file keeps the model layer navigable as it grows.
+
+3. **Add the inverse relationship property** — `var session: StudySession?`. SwiftData needs both sides declared to maintain referential integrity.
+
+**Create `Models/StudyBreak.swift`** with the corrected shape:
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class StudyBreak {
+    var startedAt: Date
+    var endedAt: Date?
+    var session: StudySession?  // inverse relationship — SwiftData keeps both sides in sync
+
+    var duration: TimeInterval { (endedAt ?? startedAt).timeIntervalSince(startedAt) }
+
+    init(startedAt: Date, endedAt: Date? = nil) {
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+    }
+}
+```
+
+Then delete the `StudyBreak` class from `StudySession.swift`.
+
+**Verify:** The new file compiles. No lingering `StudyBreak` in `StudySession.swift`.
+
+---
+
+## Step 3 — Clean Up `StudySession`
+
+**File:** `Models/StudySession.swift`
+
+`StudySession` is already `@Model final class` — good. Three things still need fixing:
+
+**1. Flatten `SessionLocation` into `StudySession`.** `SessionLocation` is its own `@Model`, but that's unnecessary overhead for three scalar fields. Delete `SessionLocation` and hoist its fields directly onto `StudySession` instead.
+
+> The current `SessionLocation` is marked as a future placeholder anyway. A separate SwiftData entity adds a join table in the underlying SQLite for no benefit here.
+
+**2. Add `@Relationship` to `breaks`.** Without it, the `[StudyBreak]` array isn't declared as a SwiftData relationship — it'll be treated as a codable blob (which may not behave correctly for `@Model` arrays). Declare it properly with a cascade delete rule.
+
+**3. Simplify `init`.** The current init requires every property including optionals. Provide defaults so the VM can call `StudySession(subject: subject)` cleanly.
+
+**Replace `StudySession.swift` with:**
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class StudySession {
+    var id: UUID = UUID()
+    var subject: Subject?
+    var subjectName: String?
+    var startedAt: Date = Date.now
+    var endedAt: Date?
+    var lastPausedAt: Date?
+    var totalActiveDuration: TimeInterval = 0
+    var totalBreakDuration: TimeInterval = 0
+    var friends: [String] = []
+    var locationDescription: String?
+    var latitude: Double?
+    var longitude: Double?
+    var studyScore: Int?
+    var notes: String?
+    var interruptionCount: Int = 0
+
+    @Relationship(deleteRule: .cascade, inverse: \StudyBreak.session)
+    var breaks: [StudyBreak] = []
+
+    var totalElapsed: TimeInterval {
+        if let endedAt { return endedAt.timeIntervalSince(startedAt) }
+        return Date().timeIntervalSince(startedAt)
+    }
+
+    init(subject: Subject? = nil) {
+        self.subject = subject
+        self.subjectName = subject?.name
+    }
+}
+```
+
+Delete `SessionLocation` and `StudyBreak` from this file — `SessionLocation` is gone (flattened), `StudyBreak` moves to its own file in Step 2.
+
+> **Why `deleteRule: .cascade`?** Breaks only exist in the context of a session. When the session is deleted, the breaks should go with it automatically — no manual cleanup needed.
+
+**Verify:** Both `StudySession.swift` and `StudyBreak.swift` compile without errors.
+
+---
+
+## Step 4 — Register New Models in the Container
+
+**File:** `App/StudyAppApp.swift`
+
+SwiftData needs to know about every model you want to persist. The container declaration is the single place where you register them all. Without this, `context.insert()` will silently fail.
+
+```swift
+// Before
+.modelContainer(for: [AppTheme.self, Subject.self])
+
+// After
+.modelContainer(for: [AppTheme.self, Subject.self, StudySession.self, StudyBreak.self])
+```
+
+> **Think of `.modelContainer(for:)` as telling SwiftData "create a database table for each of these types."** If a type isn't in this list, there's no table — and no persistence.
+
+**Verify:** The app launches without a crash. (A missing registration usually crashes immediately on launch with a "model not found in schema" error.)
+
+---
+
+## Step 5 — Wire `StudyTrackingViewModel` to Persistence
+
+**File:** `ViewModels/StudyTrackingViewModel.swift`
+
+Now that `StudySession` is a `@Model`, the VM's methods can create, mutate, and save sessions. The pattern to follow is the same one already used in `SubjectsEditorVM.swift` — each method that touches persisted data takes `context: ModelContext` as a parameter.
+
+> **Why pass `context` at the call site instead of storing it in `init`?** A `ModelContext` is tied to a specific moment in the app's lifecycle. Storing it in a VM creates subtle bugs if the context ever becomes stale. Passing it at call time keeps the VM simple, and it matches how SwiftUI expects you to work. This is the pattern the project has already committed to.
+
+Clean up the VM's stored properties to match the new `StudySession` shape:
+
+```swift
+import Foundation
+import SwiftData
+
+@Observable
+final class StudyTrackingViewModel {
+    var selectedSubject: Subject? = nil
+    var activeSession: StudySession? = nil
+    var studySessionPaused: Bool = false
+    private let breakThreshold: TimeInterval = 60 * 3
+
+    func startSession(subject: Subject? = nil, context: ModelContext) {
+        let session = StudySession(subject: subject)
+        activeSession = session
+        studySessionPaused = false
+        context.insert(session)
+    }
+
+    func pauseSession() {
+        guard let session = activeSession, !studySessionPaused else { return }
+        let now = Date()
+        session.totalActiveDuration += now.timeIntervalSince(session.startedAt)
+        session.lastPausedAt = now
+        session.isPaused = true
+        studySessionPaused = true
+    }
+
+    func resumeSession(context: ModelContext) {
+        guard let session = activeSession, let pausedAt = session.lastPausedAt else { return }
+        let now = Date()
+        let pauseDuration = now.timeIntervalSince(pausedAt)
+
+        if pauseDuration >= breakThreshold {
+            // Pause was long enough to count as a break — log it
+            let studyBreak = StudyBreak(startedAt: pausedAt, endedAt: now)
+            session.breaks.append(studyBreak)
+            session.totalBreakDuration += pauseDuration
+        }
+
+        session.isPaused = false
+        session.lastPausedAt = nil
+        studySessionPaused = false
+    }
+
+    func togglePause(context: ModelContext) {
+        studySessionPaused ? resumeSession(context: context) : pauseSession()
+    }
+
+    func endSession(score: Int? = nil, notes: String? = nil, context: ModelContext) {
+        guard let session = activeSession else { return }
+        if !studySessionPaused {
+            session.totalActiveDuration += Date().timeIntervalSince(
+                session.lastPausedAt ?? session.startedAt
+            )
+        }
+        session.endedAt = Date()
+        session.studyScore = score
+        session.notes = notes
+        try? context.save()
+        activeSession = nil
+        studySessionPaused = false
+    }
+
+    func cancelActiveSession(context: ModelContext) {
+        guard let session = activeSession else { return }
+        context.delete(session)
+        activeSession = nil
+        studySessionPaused = false
+    }
+
+    func addInterruption() {
+        activeSession?.interruptionCount += 1
+    }
+}
+```
+
+**Verify:** In the view that calls these methods, pass `modelContext` from `@Environment(\.modelContext)`:
+
+```swift
+vm.startSession(subject: vm.selectedSubject, context: modelContext)
+vm.endSession(score: selectedScore, context: modelContext)
+```
+
+To confirm sessions are actually being saved, add this temporary debug line to any view:
+
+```swift
+@Query var allSessions: [StudySession]
+// ...
+Text("Sessions saved: \(allSessions.count)")  // remove when done testing
+```
+
+---
+
+## Step 6 — Fix `PureFocusViewModel`
+
+**File:** `ViewModels/PureFocusViewModel.swift`
+
+`@Published` is already removed — `@Observable` is in place and all properties are plain `var`. One thing remains:
+
+**Remove `import SwiftUI`.** VMs shouldn't import SwiftUI — they don't know they're powering a UI, which is the whole point of the MVVM split. `import Combine` is correct to keep (it's where `AnyCancellable` comes from, used for the timer publisher).
+
+```swift
+// Remove this
+import SwiftUI
+
+// Keep this
+import Combine
+```
+
+**No SwiftData needed here.** `PureFocusViewModel` manages transient timer state only. When a focus session completes, it's `StudyTrackingViewModel.endSession(context:)` that saves to the database — not the focus timer.
+
+**Verify:** File compiles. Timer still starts, pauses, and stops in the focus view.
+
+---
+
+## Step 7 — Migrate `ThemeSettingsViewModel` to `@Observable` + Move Fetch to View
+
+**File:** `ViewModels/Settings/ThemeSettingsViewModel.swift`
+
+Two problems here:
+1. It's still `ObservableObject` + `@Published`.
+2. It holds `@Published var themes: [AppTheme]` and manually fetches via `FetchDescriptor` in `refreshThemes()`. This is the old way — it means the list only updates when you remember to call `refreshThemes()`. That's exactly the problem `@Query` solves.
+
+> **Why `@Query` in the View, not the VM?** `@Query` is a SwiftUI property wrapper — it can only live inside a `View` struct. It hooks directly into SwiftData's observation system and re-renders the View the instant data changes. A VM holding a fetched array manually never gets that automatic signal.
+
+**Migrate the VM:**
+
+```swift
+import SwiftUI
+import SwiftData
+
+@Observable
+final class ThemeSettingsViewModel {
+    var selectedColor: Color = .white
+
+    struct ThemeTemplate: Identifiable {
+        let id = UUID()
+        let name: String
+        let primary: Color
+        let secondary: Color
+        let accent: Color
+    }
+
+    let defaultThemes: [ThemeTemplate] = [
+        ThemeTemplate(name: "Summer", primary: .yellow, secondary: .orange, accent: .red),
+        ThemeTemplate(name: "Winter", primary: .gray, secondary: .blue, accent: .white),
+        ThemeTemplate(name: "Dummy", primary: .black, secondary: .green, accent: .blue)
+    ]
+
+    func createTheme(named name: String, primary: Color, secondary: Color, accent: Color, using context: ModelContext) {
+        context.insert(AppTheme(name: name, primary: primary, secondary: secondary, accent: accent))
+    }
+
+    // Call this once on first launch to seed defaults
+    func ensureDefaultsExist(existingCount: Int, using context: ModelContext) {
+        guard existingCount == 0 else { return }
+        for template in defaultThemes {
+            context.insert(AppTheme(name: template.name, primary: template.primary, secondary: template.secondary, accent: template.accent))
+        }
+    }
+}
+```
+
+**In the View, add `@Query` and call `ensureDefaultsExist` once:**
+
+```swift
+struct ThemeSettingsView: View {
+    @Query(sort: \AppTheme.name) var themes: [AppTheme]
+    @Environment(\.modelContext) var modelContext
+    @State private var vm = ThemeSettingsViewModel()
+
+    var body: some View {
+        List(themes) { theme in
+            Text(theme.name)
+        }
+        .task {
+            // Runs once when the view appears; seeds defaults if empty
+            vm.ensureDefaultsExist(existingCount: themes.count, using: modelContext)
+        }
+    }
+}
+```
+
+Delete `refreshThemes()`, `bootstrap()`, and the `@Published var themes` property from the VM entirely.
+
+**Verify:** Settings screen displays themes. Adding a new theme via `createTheme(named:...)` updates the list instantly without any manual refresh call.
+
+---
+
+## Step 8 — Migrate `SocialFeedViewModel` to `@Observable`
+
+**File:** `ViewModels/SocialFeedViewModel.swift`
+
+No SwiftData needed — the social feed is remote/network data. This is purely a pattern cleanup.
+
+```swift
+// Before
+final class SocialFeedViewModel: ObservableObject {
+    @Published var items: [SocialFeedItem]
+    @Published var currentSessionTime: String
+    // ...
+}
+
+// After
+@Observable
+final class SocialFeedViewModel {
+    var items: [SocialFeedItem]
+    var currentSessionTime: String
+    // ...
+}
+```
+
+Remove `import Combine`. Remove `import SwiftUI` if it was only there for `ObservableObject`. The rest of the VM stays unchanged.
+
+**Verify:** Social feed view renders sample items. No observable-related warnings in the console.
+
+---
+
+## What We're Not Migrating (and Why)
+
+| File | Reason |
+|---|---|
+| `Models/User.swift` (`UserProfile`) | Needs auth/backend design first. Premature to lock in a SwiftData shape for something that depends on external systems. |
+| `Models/SocialFeed.swift`, `Models/ListItem.swift` | Remote display DTOs. They'll come from a network layer, not a local database. |
+| `Models/RemoteUser.swift` | Network model — `Codable` is the right tool, not SwiftData. |
+| `Models/StudySession.swift` (`SessionLocation` struct) | Deleted — flattened into `StudySession` directly (Steps 2–3). |
+
+---
+
+## Recurring Patterns: Your Quick Reference
+
+These rules apply throughout the codebase. When in doubt, check `SubjectsEditorVM.swift` — it's already the canonical correct example.
+
+**Models**
+- Always `@Model final class` — never a struct.
+- Provide default values for all properties so SwiftData can create rows without an explicit init.
+- Arrays of `@Model` types become relationships — declare them with `@Relationship`.
+- Arrays of primitive types (`String`, `Int`, `Double`) are fine as-is.
+
+**ViewModels**
+- `@Observable` class — never `ObservableObject`.
+- Never `@Published` inside `@Observable` — plain `var` is all you need.
+- No `import SwiftUI` — VMs don't know they're powering a UI.
+- Methods that mutate persistent data take `context: ModelContext` as a parameter — never stored in `init`.
+
+**Views**
+- `@Query` for reads — it's live, it auto-refreshes, it belongs in the View.
+- `@Environment(\.modelContext)` for writes — always available because the app root sets up `.modelContainer(for:)`.
+- Initialize VMs non-optionally: `@State private var vm = MyVM()` — no optional unwrapping needed.
+- Pass `modelContext` to VM methods at call time: `vm.save(context: modelContext)`.
+
+**App Root**
+- Every `@Model` type must be listed in `.modelContainer(for:)` in `StudyAppApp.swift`. Missing = no table = silent failure on insert.
+
+---
+
+## End-to-End Verification
+
+Once all steps are done, run through this checklist:
+
+**Build:**
+```bash
+xcodebuild build -project studyApp.xcodeproj -scheme studyApp -destination generic/platform=iOS
+```
+
+**Session persistence:**
+1. Start a session, pause it, resume it, end it.
+2. Force-quit and relaunch the app.
+3. Add a temporary `@Query var sessions: [StudySession]` + `Text("Sessions: \(sessions.count)")` to any view — the count should persist across launches.
+
+**Theme persistence:**
+1. Open Settings → add a new theme.
+2. Force-quit and relaunch — the theme should still be there.
+3. Confirm the list updates immediately after adding (no refresh button needed).
+
+**Clean up debug lines** before shipping — any `Text("Sessions: \(count)")` added for testing.

--- a/plan.md
+++ b/plan.md
@@ -1,42 +1,6 @@
-# Plan: Inject UserProfileStore into SwiftUI Environment
-
-**TL;DR:**
-Expose `UserProfileStore` at the app root via `@StateObject` and `.environmentObject()` so all views can access it without tight coupling to the singleton. This makes the store tree-wide accessible, improves testability, and removes the need for views to call `UserProfileStore.shared` directly. We'll audit existing views to update them from singleton access to `@EnvironmentObject`.
-
-## Steps
-
-1. **Update [StudyAppApp.swift](studyApp/App/StudyAppApp.swift)**
-   - Add `@StateObject var userStore = UserProfileStore.shared`
-   - Inject via `.environmentObject(userStore)` on `MainTabView()`
-
-2. **Audit existing usage of `UserProfileStore.shared`**
-   - Search codebase for all references to `UserProfileStore.shared`
-   - Document which ViewModels and Views use it
-   - Identify which should switch to `@EnvironmentObject` vs. which should keep singleton access (e.g., if a ViewModel is used outside SwiftUI context)
-
-3. **Update ViewModels that use the store**
-   - For ViewModels like `UserProfileStore`, `SubjectStore`, `StudyTrackingViewModel` that need the user store:
-     - Remove direct `UserProfileStore.shared` calls
-     - Inject store as a parameter in `init()` instead
-     - Views provide the store from `@EnvironmentObject`
-
-4. **Update Views that directly access the store**
-   - Replace `@StateObject private var store = UserProfileStore.shared` with `@EnvironmentObject var store: UserProfileStore`
-   - Remove any direct singleton calls
-
-5. **Test environment injection**
-   - Verify the app launches without crashes
-   - Check that changes to profile persist correctly
-   - Test in previews by passing a mock `UserProfileStore` as `.environmentObject(mockStore)`
-
-## Verification
-
-- App builds and runs
-- Profile changes save to disk automatically
-- Previews work by injecting test stores
-- No "Fatal error: No ObservedObject of type UserProfileStore" warnings
-
-## Decisions
-
-- Chose environment injection over singleton to enable dependency injection and testability
-- `UserProfileStore.shared` stays as a default initializer (fallback for app root), not removed entirely
+[ ] Remove Store singleton dependencies
+[ ] Add @Query for all database reads
+[ ] Add @Environment(\.modelContext) for writes
+[ ] Initialize ViewModel as @State (non-optional)
+[ ] Pass modelContext to VM methods at call site
+[ ] Test with .modelContainer(for: Model.self, inMemory: true) in previews

--- a/studyApp/App/StudyAppApp.swift
+++ b/studyApp/App/StudyAppApp.swift
@@ -10,7 +10,8 @@ struct StudyAppApp: App {
         WindowGroup {
             MainTabView()
         }
-        .modelContainer(for: [AppTheme.self])
+        .modelContainer(for: [AppTheme.self, Subject.self]) //store AppThemes & Subjects in SwiftData
+        
     }
 }
 

--- a/studyApp/App/StudyAppApp.swift
+++ b/studyApp/App/StudyAppApp.swift
@@ -10,7 +10,7 @@ struct StudyAppApp: App {
         WindowGroup {
             MainTabView()
         }
-        .modelContainer(for: [AppTheme.self, Subject.self]) //store AppThemes & Subjects in SwiftData
+        .modelContainer(for: [AppTheme.self, Subject.self, StudySession.self, StudyBreak.self, SessionLocation.self])
         
     }
 }

--- a/studyApp/Models/StudySession.swift
+++ b/studyApp/Models/StudySession.swift
@@ -4,95 +4,175 @@
 //  Data models for study sessions.
 
 import Foundation
+import SwiftData
 
-// MARK: - Supporting Types
+import os
+//let logger = Logger()
 
-struct SessionLocation: Codable, Equatable { //optional placeholder for future location tagging
-    var description: String?
+
+// MARK: - SessionLocation
+@Model
+final class SessionLocation { //optional placeholsder for future location tagging
+    var locationDescription: String?
     var latitude: Double?
     var longitude: Double?
+    var locationLabel: String
+    
+    // Designated initializer
+    init(locationDescription: String? = nil, latitude: Double? = nil, longitude: Double? = nil, locationLabel: String) {
+        self.locationDescription = locationDescription
+        self.latitude = latitude
+        self.longitude = longitude
+        self.locationLabel = locationLabel
+    }
+    
+    // Convenience initializer for pure location
+    convenience init(latitude: Double, longitude: Double) {
+        self.init(locationDescription: nil, latitude: latitude, longitude: longitude, locationLabel: "")
+    }
+    
+    // Convenience initializer for placeholder
+    convenience init() {
+        self.init(locationDescription: "Placeholder Description", latitude: 0.0, longitude: 0.0, locationLabel: "Placeholder Label")
+    }
 }
 
-struct StudyBreak: Identifiable, Codable, Equatable { //records a single breakPeriod
-    var id: UUID = UUID()
-    var startedAt: Date
-    var endedAt: Date
+//fquerbuadv    38u hwr fju wefn\
 
-    var duration: TimeInterval { endedAt.timeIntervalSince(startedAt) } //computed property
-}
 
-/// Represents an individual study session, both while active and once completed.
-struct StudySession: Identifiable, Codable {
-    var id: UUID
-    var subject: Subject?
-    var subjectName: String?
+
+
+
+
+//MARK: StudyBreak
+@Model
+final class StudyBreak { //records a single breakPeriod
+    
+    //convert startedAt and endedAt from TimeInterval to Date.
     var startedAt: Date
     var endedAt: Date?
-    var isPaused: Bool
 
-    //could probably combine these two into one property which isn't tracked but computed and displayed on the focus screen
-    var lastResumedAt: Date 
-    var lastPausedAt: Date?
+    //duration of break; equal to 0 if it's still in progress (no value for endedAt), otherwise we'll update and save the break when we've ended it.
+    var duration: TimeInterval{
+        if let endedAt = endedAt {
+            return endedAt.timeIntervalSince(startedAt)
+        } else {
+            return 0
+        }
+    }
+    
+    init(startedAt: Date, endedAt: Date) {
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+    }
+    
+    //if initiated empty, we can start it but have no end attatched.
+    init() {
+        self.startedAt = Date.now
+    }
+}
 
-    var totalActiveDuration: TimeInterval
-    var totalBreakDuration: TimeInterval
-    var breaks: [StudyBreak]
-    var companions: [String] // placeholder for other users in the session
+
+/// Represents an individual study session, both while active and once completed.
+@Model
+final class StudySession: Identifiable {
+    var id: UUID
+    
+    var subject: Subject?  //optional
+    var subjectName: String? //optional
+    var startedAt: Date
+    var endedAt: Date? //optional
+
+    var lastPausedAt: Date? //optional
+
+    var totalActiveDuration: TimeInterval { //start to either end time or now MINUS (forEach in breaks --> duration)
+        //if we this is a finished studySession
+        if let endedAt {
+            var breaksTotal: TimeInterval = 0;
+
+            (breaks ?? []).forEach { each in //safely fallback if no breaks
+                breaksTotal += each.duration
+            }
+            //logger.log("breaks added up to \(breaksTotal)")
+
+
+            //return total duration minus any breaks. if none, then it's just the totalDuration.
+            return totalDuration - breaksTotal;
+        }
+        
+        //if session is inprog
+        return totalDuration;
+	
+    }
+    var totalBreakDuration: TimeInterval?
+    
+    var breaks: [StudyBreak]?
+    var friends: [String]? // placeholder for other users in the session
     var location: SessionLocation?
     var studyScore: Int? // 0...10 rating at completion
     var notes: String?
+    
     var interruptionCount: Int
+    
+    //total duratrion of session between end date - start OR current date - start.
+    var totalDuration: TimeInterval {
+        if let endedAt {
+            return endedAt.timeIntervalSince(startedAt)
+        }
+        return Date().timeIntervalSince(startedAt)
+    }
+    
+    
 
     // Future analytics: screen time per app/category can be attached here once available.
-
+    
+    
+    //Default initialiser, parsing all required parameters, & optional for optionals.
     init(
         id: UUID = UUID(),
-        subject: Subject? = nil,
-        subjectName: String? = nil,
-        startedAt: Date = Date.now,
-        endedAt: Date? = nil,
-        isPaused: Bool = false,
-        lastResumedAt: Date = Date(),
-        lastPausedAt: Date? = nil,
-        activeDuration: TimeInterval = 0, //computed later
-        totalBreakDuration: TimeInterval = 0, //computed later
-        breaks: [StudyBreak] = [],
-        companions: [String] = [],
-        location: SessionLocation? = nil,
-        studyScore: Int? = nil,
-        notes: String? = nil,
-        interruptionCount: Int? = nil
+        subject: Subject,
+        subjectName: String?,
+        startedAt: Date,
+        endedAt: Date?,
+        lastPausedAt: Date?,
+        activeDuration: TimeInterval,
+        totalBreakDuration: TimeInterval?,
+        breaks: [StudyBreak]?,
+        friends: [String] = [], //empty for now
+        location: SessionLocation?,
+        studyScore: Int?,
+        notes: String?,
+        interruptionCount: Int?
     ) {
         self.id = id
         self.subject = subject
-        self.subjectName = subject?.name
+        self.subjectName = subjectName
         self.startedAt = startedAt
         self.endedAt = endedAt
-        self.isPaused = isPaused
-        self.lastResumedAt = lastResumedAt
         self.lastPausedAt = lastPausedAt
-        self.totalActiveDuration = activeDuration
         self.totalBreakDuration = totalBreakDuration
         self.breaks = breaks
-        self.companions = companions
+        self.friends = friends
         self.location = location
         self.studyScore = studyScore
         self.notes = notes
         self.interruptionCount = interruptionCount ?? 0
     }
 
-    var totalElapsed: TimeInterval {
-        if let endedAt {
-            return endedAt.timeIntervalSince(startedAt)
-        }
-        return Date().timeIntervalSince(startedAt)
-    }
-
-    var runningActiveDuration: TimeInterval {
-        if isPaused {
-            return totalActiveDuration
-        } else {
-            return totalActiveDuration + Date().timeIntervalSince(lastResumedAt)
-        }
+    convenience init() {
+        self.init(
+            subject: Subject(name: "Temporary Subject", code: "xyz"),
+            subjectName: nil,
+            startedAt: Date(),
+            endedAt: nil,
+            lastPausedAt: nil,
+            activeDuration: 0,
+            totalBreakDuration: 0,
+            breaks: [],
+            location: nil,
+            studyScore: nil,
+            notes: nil,
+            interruptionCount: nil
+        )
     }
 }

--- a/studyApp/Models/Subject.swift
+++ b/studyApp/Models/Subject.swift
@@ -4,9 +4,11 @@
 //  Model representing a study subject.
 
 import Foundation
+import SwiftData
 
-struct Subject: Identifiable, Codable, Hashable {
-    let id: UUID
+@Model
+final class Subject {
+    var id: UUID
     var name: String
     var code: String
     var createdAt: Date

--- a/studyApp/Models/User.swift
+++ b/studyApp/Models/User.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 
-struct UserProfile: Codable { //holds all local data, as well as an optional link to an external account
+struct UserProfile { //holds all local data, as well as an optional link to an external account
     var id: UUID
     var userHandle: String? //todo, register online later
     var userStatus: ActiveStatus
@@ -18,32 +18,12 @@ struct UserProfile: Codable { //holds all local data, as well as an optional lin
     var auth: AuthState
     var createdAt: Date
     var isPaused: Bool
-    var lastResumedAt: Bool
+    var lastResumedAt: Date
     var lastActiveAt: Date
     var subjects: [Subject]
     var studySessions: [StudySession] = []
 
 
-    func storeStudySessionsLocally() { ///UNTESTED CODE
-        // Encode the sessions array and write it to the app's Documents directory.
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
- ///UNTESTED CODE
-        do {
-            let data = try encoder.encode(studySessions)
-            let fm = FileManager.default
-            let docsURL = try fm.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-            let fileURL = docsURL.appendingPathComponent("studySessions_\(id.uuidString).json")
- ///UNTESTED CODE
-            try data.write(to: fileURL, options: [.atomic])
-            #if DEBUG
-            print("Stored study sessions to: \(fileURL.path)")
-            #endif
-        } catch {
-            print("Failed to store study sessions: \(error)")
-        }
-         ///UNTESTED CODE
-    }
 }
 
 

--- a/studyApp/ViewModels/PureFocusViewModel.swift
+++ b/studyApp/ViewModels/PureFocusViewModel.swift
@@ -7,7 +7,8 @@
 import SwiftUI
 import Combine
 
-class PureFocusViewModel: ObservableObject {
+@Observable
+final class PureFocusViewModel {
     
     // MARK: - Sheet Properties
     
@@ -15,18 +16,18 @@ class PureFocusViewModel: ObservableObject {
     // updates any Views observing this model when it changes
     
     // MARK: - Timer Properties
-    
+
     /// Total duration for the focus session in seconds (default: 25 minutes)
-    
+
     /// Elapsed time in seconds since timer started
-    @Published var elapsedTime: TimeInterval = 0
-    
-    @Published var currentTimerTotalDuration: TimeInterval = 5 // default 5s, change to 0 later
-    
+    var elapsedTime: TimeInterval = 0
+
+    var currentTimerTotalDuration: TimeInterval = 5 // default 5s, change to 0 later
+
     /// Whether the timer is currently running
-    @Published var timerActivelyRunning: Bool = false //no timers, initially
-    
-    @Published var timerActivelyExists: Bool = false //tracks if there is any timer that currently exists
+    var timerActivelyRunning: Bool = false //no timers, initially
+
+    var timerActivelyExists: Bool = false //tracks if there is any timer that currently exists
     
     /// Computed progress value (0.0 to 1.0) for the gradient animation
     var timerProgress: CGFloat { //need this to track for background

--- a/studyApp/ViewModels/Settings/SubjectsEditorVM.swift
+++ b/studyApp/ViewModels/Settings/SubjectsEditorVM.swift
@@ -3,9 +3,8 @@ import SwiftData
 @Observable
 final class SubjectsEditorVM {
 
-    //state not neded in classes; only structs
-    // @State is only needed for Views, as it's an individually observerd component; not for ViewModels
-    var newSubjectName: String = ""
+    // State is not needed in classes; only in structs.
+    // @State is only needed for Views (value types) — not for ViewModels.
     var newSubjectCode: String = ""
 
     var canAddSubject: Bool {

--- a/studyApp/ViewModels/Settings/SubjectsEditorVM.swift
+++ b/studyApp/ViewModels/Settings/SubjectsEditorVM.swift
@@ -1,0 +1,27 @@
+import SwiftData
+
+@Observable
+final class SubjectsEditorVM {
+
+    //state not neded in classes; only structs
+    // @State is only needed for Views, as it's an individually observerd component; not for ViewModels
+    var newSubjectName: String = ""
+    var newSubjectCode: String = ""
+
+    var canAddSubject: Bool {
+        newSubjectName.count > 0 && newSubjectName.count <= 32 &&
+        newSubjectCode.count > 0 && newSubjectCode.count <= 4
+    }
+    
+    //recieve context as soon as called
+    func addSubject(context: ModelContext) {
+        guard canAddSubject else { return }
+        context.insert(Subject(name: newSubjectName, code: newSubjectCode.uppercased()))
+        newSubjectName = ""
+        newSubjectCode = ""
+    }
+
+    func removeSubject(_ subject: Subject, context: ModelContext) {
+        context.delete(subject)
+    }
+}

--- a/studyApp/Views/Components/ActiveSubjectList.swift
+++ b/studyApp/Views/Components/ActiveSubjectList.swift
@@ -4,10 +4,17 @@
 //  A picker component for selecting the active study subject.
 
 import SwiftUI
+import SwiftData
+
+
 
 struct ActiveSubjectList: View {
-    @ObservedObject var studyTrackingModel: StudyTrackingViewModel
-    var subjects: [Subject]
+    @State private var studyTrackingModel = StudyTrackingViewModel()
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Query private var subjects: [Subject]
+
     var isEnabled: Bool
 
     @State private var subjectSelection: Subject?

--- a/studyApp/Views/Focus/PureFocusView.swift
+++ b/studyApp/Views/Focus/PureFocusView.swift
@@ -8,12 +8,14 @@ import SwiftUI
 //need to use white UI elements exclusively.
 struct PureFocusView: View {
     
+    @Environment(\.dismiss) var dismiss //native dismiss function
+    
     @State var timerTimeInterval: TimeInterval = 0 //0.0 gets binded to our durationpicker, so this gets changed as the picker changes value.
     
     // MARK: - State Properties
     
-    @StateObject private var viewModel = PureFocusViewModel()
-    
+    @State private var vm = PureFocusViewModel()
+
     //Lock (focus feature)
     @State private var focusLockEnabled: Bool = false;
 
@@ -27,8 +29,8 @@ struct PureFocusView: View {
         ZStack(alignment: .bottom) {
             // Animated gradient background
             TimerGradientBackground(
-                progress: viewModel.timerProgress,
-                isTimerActive: $viewModel.timerActivelyRunning
+                progress: vm.timerProgress,
+                isTimerActive: $vm.timerActivelyRunning
             )
             
             VStack() {
@@ -47,6 +49,13 @@ struct PureFocusView: View {
             CustomBottomSheet()
         }
         .toolbar(.hidden, for: .tabBar)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button("Cancel") {
+                    dismiss() // Programmatic dismissal
+                }
+            }
+        }
         .foregroundColor(dynamicForegroundColor)
         .navigationBarBackButtonHidden(false)
     }
@@ -65,23 +74,9 @@ struct PureFocusView: View {
                 
             
             // Duration picker (when timer is not running)
-            if !viewModel.timerActivelyRunning && viewModel.elapsedTime == 0 {
+            if !vm.timerActivelyRunning && vm.elapsedTime == 0 {
                 durationPicker
             }
-            
-//            //DEBUG
-//            if (viewModel.timerActivelyRunning) {
-//                Text("running: TRUE")
-//            } else {
-//                Text("running: FALSE")
-//            }
-//            
-//            if (viewModel.timerActivelyExists) { //DEBUG
-//                Text("exists: TRUE")
-//            } else {
-//                Text("exists: FALSE")
-//            }
-            
             
             // Timer control buttons
             HStack(spacing: 20) {
@@ -91,13 +86,13 @@ struct PureFocusView: View {
                 // to manually manage foreground/background colors or pressed states.
                 // Start/Pause button
                 Button(action: {
-                    viewModel.toggleTimer()
+                    vm.toggleTimer()
                 }) {
                     HStack(spacing: 8) {
-                        Image(systemName: viewModel.timerActivelyRunning ? "pause.fill" : "play.fill")
+                        Image(systemName: vm.timerActivelyRunning ? "pause.fill" : "play.fill")
                         
-                        if (viewModel.timerActivelyExists) {
-                            Text(viewModel.timerActivelyRunning ? "Pause" : "Resume")
+                        if (vm.timerActivelyExists) {
+                            Text(vm.timerActivelyRunning ? "Pause" : "Resume")
                         } else {
                             Text("Start")
                         }
@@ -124,8 +119,8 @@ struct PureFocusView: View {
                             .contentTransition(.symbolEffect(.replace.magic(fallback: .offUp.byLayer), options: .nonRepeating))
                             
                         
-                        if (viewModel.timerActivelyExists) {
-                            Text(viewModel.timerActivelyRunning ? "Pause" : "Resume")
+                        if (vm.timerActivelyExists) {
+                            Text(vm.timerActivelyRunning ? "Pause" : "Resume")
                         } else {
                             Text("Start")
                         }
@@ -136,10 +131,10 @@ struct PureFocusView: View {
                 //UITWEAK
                 // Reset button (only show when timer has started)
                 // Uses the same .glass style so it visually matches the other controls.
-                if viewModel.elapsedTime > 0 {
+                if vm.elapsedTime > 0 {
                     Button(action: {
                         withAnimation {
-                            viewModel.resetTimer()
+                            vm.resetTimer()
                         }
                     }) {
                         Image(systemName: "arrow.counterclockwise")
@@ -160,7 +155,7 @@ struct PureFocusView: View {
         
         VStack(spacing: 8) {
 
-            DurationPicker(duration: $viewModel.currentTimerTotalDuration, minHours: $minHours, maxHours: $maxHours, minMinutes: $minMinutes, maxMinutes: $maxMinutes) //
+            DurationPicker(duration: $vm.currentTimerTotalDuration, minHours: $minHours, maxHours: $maxHours, minMinutes: $minMinutes, maxMinutes: $maxMinutes) //
         }
     }
     
@@ -173,17 +168,17 @@ struct PureFocusView: View {
     // MARK: - Computed Properties
     
     private var remainingTimeFormatted: String {
-        viewModel.remainingTime.formattedClock
+        vm.remainingTime.formattedClock
     }
     
     /// Dynamically adjust foreground color based on background brightness
     private var dynamicForegroundColor: Color {
-        viewModel.timerProgress > 0.6 ? .black : .white
+        vm.timerProgress > 0.6 ? .black : .white
     }
     
     //new timer stuff
     var remainingTime: some View {
-        Text("vm.totalduration: \(viewModel.currentTimerTotalDuration)")
+        Text("vm.totalduration: \(vm.currentTimerTotalDuration)")
     }
 }
     

--- a/studyApp/Views/Focus/StudyTrackingView.swift
+++ b/studyApp/Views/Focus/StudyTrackingView.swift
@@ -6,6 +6,7 @@ import Combine
 struct StudyTrackingView: View {
     
     // MARK: - State Properties
+    @State private var pureFocusViewState = false;
     
     @State private var focusSliderValue: Double = 0
     @State private var timerInProgress: Bool = false
@@ -20,9 +21,10 @@ struct StudyTrackingView: View {
     @State var timeSinceLastBreakStarted: TimeInterval = 61 //time since last break started
     
     // MARK: - ViewModels
+
+    @State private var vm = StudyTrackingViewModel()
     
-    @StateObject private var vm = StudyTrackingViewModel()
-    @StateObject private var userProfileStore = UserProfileStore.shared
+    
     
     // MARK: - Helpers
     
@@ -102,30 +104,17 @@ struct StudyTrackingView: View {
             .padding(.top, 32)
             .padding(.bottom, 24)
         }
-        
+
 //        .sheet(isPresented: $isLeaderboardPresented) {
 //            LeaderboardSheetView()
 //                .padding(10)
 //                .presentationDragIndicator(.visible)
 //                .presentationBackgroundInteraction(.enabled)
 //                .presentationDetents([.height(50), .fraction(0.3), .fraction(0.9)])
-//                
-//            
-//            
+//
+//
+//
 //        }
-        .onChange(of: userProfileStore.profile.subjects) { old, new in
-            if vm.selectedSubject == nil, let first = new.first {
-                vm.updateSubjectSelection(first)
-            }
-            
-            
-//                .onChange(of: currentTrackWidth) { oldValue, newValue in
-//                    trackWidth = newValue
-//                }
-        }
-        .onReceive(vm.$activeSession) { session in
-            currentStudySessionInProgress = session != nil
-        }
 
 
 
@@ -141,8 +130,6 @@ struct StudyTrackingView: View {
                     .foregroundColor(.secondary)
 
                 ActiveSubjectList(
-                    studyTrackingModel: vm,
-                    subjects: userProfileStore.profile.subjects,
                     isEnabled: !currentStudySessionInProgress
                 )
             }
@@ -260,7 +247,7 @@ struct StudyTrackingView: View {
                     .frame(maxWidth: .infinity, alignment: .trailing)
                 }
                 .padding(.horizontal, 20)
-                
+                         
                 
                 HStack { //child hstack2, aligned to be left-most within the available space
                     Button {
@@ -279,7 +266,7 @@ struct StudyTrackingView: View {
                                         Text("Pause")
                                     }
                                     .buttonStyle(.glass)
-                                    .buttonSizing(.flexible)
+                                    .frame(maxWidth: .infinity)
 
                                     
 
@@ -288,10 +275,10 @@ struct StudyTrackingView: View {
                                     Button {
                                         
                                     } label: {
-//                                        Text("end")
+                                        Text("end")
                                     }
                                     .buttonStyle(.glass)
-                                    .buttonSizing(.automatic)
+                                    .buttonSizing(.fitted)
 
 
                                 }
@@ -313,11 +300,12 @@ struct StudyTrackingView: View {
                         .font(.headline)
                         .padding(.horizontal, 10) //padding for start button, makes button wider than text
                         .padding(.vertical, 12)
-                        .frame(maxWidth: 150)
+                        .frame(maxWidth: .infinity)
 
                     }
                     .animation(.easeInOut(duration: 0.3), value: timerInProgress)
                     .frame(alignment: .leading)
+                    .padding(.leading, 0)
                     
                 }
                 .frame(maxWidth: .infinity, alignment: .leading) //align to left
@@ -349,7 +337,7 @@ struct StudyTrackingView: View {
         //UITWEAK
         // Replace the semi-transparent white fill with a glass effect background so the
         // slider tray adapts to the gradient behind it and feels part of the OS chrome.
-        FocusIntensitySlider(value: $focusSliderValue, range: 0...100, sliderDraggableElementWidth: $sliderDraggableElementWidth, sliderDraggableElementHeight: $sliderDraggableElementHeight)
+        FocusIntensitySlider(pureFocusViewActive: $pureFocusViewState ,value: $focusSliderValue, range: 0...100, sliderDraggableElementWidth: $sliderDraggableElementWidth, sliderDraggableElementHeight: $sliderDraggableElementHeight)
             .frame(height: 40)
             .accessibilityLabel("Focus intensity")
             .padding(.vertical, 14)

--- a/studyApp/Views/Settings/AppSettings.swift
+++ b/studyApp/Views/Settings/AppSettings.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import SwiftData
+struct AppSettings {
+    
+    //default themes
+
+    
+    //initialise and append themes
+    var themesArray: [AppTheme] = []
+    
+    //initializer to set up default themes
+    init() { //when created, update default values
+        
+        //MARK: Themes
+    
+        themesArray = defaultThemes
+        
+//        getUserThemesFromStorage() -> ? {
+        
+//    }
+    }
+    
+    
+
+    
+
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    //MARK: Themes
+
+    let defaultThemes: [AppTheme] = [
+        AppTheme(name: "Default", primary: .white, secondary: .blue, accent: .gray)
+    ]
+    
+    
+}

--- a/studyApp/Views/Settings/SubjectsEditor.swift
+++ b/studyApp/Views/Settings/SubjectsEditor.swift
@@ -1,25 +1,22 @@
 import SwiftUI
+import SwiftData
 
 struct SubjectsEditor: View {
-    @StateObject private var userProfileStore = UserProfileStore.shared
-    @State private var newSubjectName = ""
-    @State private var newSubjectCode = ""
+    @Environment(\.modelContext) private var modelContext
+    @State private var vm = SubjectsEditorVM()
     @FocusState private var isNameFocused: Bool
+    
     @Binding var isPresented: Bool
+    @Binding var currentDetent: PresentationDetent
 
-    private var canAddSubject: Bool {
-        !newSubjectName.trimmingCharacters(in: .whitespaces).isEmpty &&
-        newSubjectCode.trimmingCharacters(in: .whitespaces).count <= 4 &&
-        !newSubjectCode.trimmingCharacters(in: .whitespaces).isEmpty
-    }
+    @Query var subjects: [Subject]
 
     var body: some View {
         VStack(spacing: 20) {
-
             HStack {
                 Text("Edit Subjects")
                     .font(.title.weight(.bold))
-                    
+
                 Spacer()
                 Button(action: { isPresented.toggle() }) {
                     Image(systemName: "xmark")
@@ -29,15 +26,15 @@ struct SubjectsEditor: View {
                 .shadow(radius: 10)
                 .accessibilityLabel("Close editor")
             }
-            
+
             List {
-                if userProfileStore.profile.subjects.isEmpty {
+                if subjects.isEmpty {
                     Text("No subjects")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .listRowBackground(Color.clear)
                 } else {
-                    ForEach(userProfileStore.profile.subjects) { subject in
+                    ForEach(subjects) { subject in
                         HStack {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text(subject.name)
@@ -57,8 +54,7 @@ struct SubjectsEditor: View {
                     .onDelete { indexSet in
                         withAnimation(.easeInOut) {
                             indexSet.forEach { index in
-                                let subject = userProfileStore.profile.subjects[index]
-                                userProfileStore.removeSubject(id: subject.id)
+                                vm.removeSubject(subjects[index], context: modelContext)
                             }
                         }
                     }
@@ -66,55 +62,54 @@ struct SubjectsEditor: View {
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            
+
             ZStack {
-                
                 VStack(spacing: 12) {
-                    TextField("Subject name", text: $newSubjectName)
+                    TextField("Subject name", text: $vm.newSubjectName)
                         .textContentType(.givenName)
                         .submitLabel(.next)
                         .focused($isNameFocused)
-                        
+                    
+                    DotStyleDivider(orientation: .horizontal)
+
                     ZStack(alignment: .trailing) {
-                        TextField("Subject code (e.g. MATH101)", text: $newSubjectCode)
+                        TextField("Subject code (e.g. MATH101)", text: $vm.newSubjectCode)
                             .autocorrectionDisabled()
                             .submitLabel(.done)
-                            .onSubmit(addSubject)
+                            .onSubmit { vm.addSubject(context: modelContext) }
                             .padding(.trailing, 40)
 
-                        Text("\(newSubjectCode.trimmingCharacters(in: .whitespaces).count)/4")
-                            .foregroundColor(newSubjectCode.count > 4 ? .red : .gray)
+                        Text("\(vm.newSubjectCode.count)/4")
+                            .foregroundColor(vm.newSubjectCode.count > 4 ? .red : .gray)
                             .font(.caption)
                             .padding(.trailing, 8)
                             .opacity(0.7)
                     }
                 }
                 .padding()
-                .background(.thinMaterial)
+                .background(.ultraThinMaterial)
                 .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
             }
-            
-            Button(action: addSubject) {
+
+            Button(action: { vm.addSubject(context: modelContext) }) {
                 Label("Add Subject", systemImage: "plus.circle.fill")
                     .font(.headline)
                     .frame(maxWidth: .infinity)
+                    .foregroundColor(Color(.red))
+
+                    
             }
             .buttonStyle(.borderedProminent)
-            .disabled(!canAddSubject)
-            .opacity(canAddSubject ? 1 : 0.5)
+            .disabled(!vm.canAddSubject)
+            .opacity(vm.canAddSubject ? 1 : 0.5)
+            .background(.thinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+
         }
         .padding([.top, .horizontal])
     }
 
-    private func addSubject() {
-        guard canAddSubject else { return }
-        let subject = Subject(name: newSubjectName, code: newSubjectCode.uppercased())
-        userProfileStore.addSubject(subject)
-        newSubjectName = ""
-        newSubjectCode = ""
-        isNameFocused = true
-    }
-    
     private func formatCreatedDate(_ date: Date) -> String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
@@ -123,11 +118,16 @@ struct SubjectsEditor: View {
 }
 
 #Preview {
+    
+    @Previewable @State var currentDetent: PresentationDetent = .medium
+    
     ZStack {
         Color.gray.opacity(0.2).ignoresSafeArea()
         VStack {
             Spacer()
-            SubjectsEditor(isPresented: .constant(true))
+            SubjectsEditor(isPresented: .constant(true), currentDetent: $currentDetent)
+                
         }
     }
+    .modelContainer(for: Subject.self, inMemory: true)
 }


### PR DESCRIPTION
## Summary
- `StudySession`, `StudyBreak`, `SessionLocation`: migrated from `struct` → `@Model final class`
- `ActiveSubjectList`: drops `UserProfileStore`, uses `@Query` for subjects directly
- `StudyTrackingView`: updated to `@State vm` pattern, no legacy store refs
- `StudyAppApp`: registers all session models in modelContainer
- Docs: `SwiftDataImplementation.md`, `HowToTestSwiftData.md`, model docs added

## What's intentionally incomplete
- `StudyTrackingViewModel` is kept at master's working implementation as the **starting point** for the SwiftData rewrite — the session tracking logic (`startSession`, `pauseSession`, `resumeSession`, `endSession`) needs to be rewritten to accept `ModelContext` and persist to SwiftData
- `StudySession` is missing `isPaused` / `lastResumedAt` equivalents — `runningActiveDuration` currently always returns `totalActiveDuration` and won't track live elapsed time until this is resolved
- `User.swift` migration is incomplete

## Test plan
- [ ] App compiles without errors
- [ ] StudyTrackingView renders with no crashes
- [ ] Subjects load via `@Query` in `ActiveSubjectList`
- [ ] Session model registration doesn't conflict with existing `Subject`/`AppTheme` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)